### PR TITLE
Converted AsyncTask to AsyncTaskLoader

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,6 +52,10 @@
     <string name="current_api_request_type_key" translatable="false">
         current_api_request_type
     </string>
+    <string name="cached_api_request_type_key" translatable="false">
+        cached_api_request_type
+    </string>
+    <string name="cached_movies_key" translatable="false">cache_movies</string>
 
     <string name="no_network_available_error">
         Network currently unavailable. Please try again later.


### PR DESCRIPTION
To help better handle the Android lifecycle, I've converted the AsyncTask that performs the network call into an AsyncTaskLoader. Additionally I have provided some caching to this, so if the data has already been fetched and the sort option is the same, it'll just return the previously cached results.